### PR TITLE
Update bernoulli.py

### DIFF
--- a/thompson_sampling/bernoulli.py
+++ b/thompson_sampling/bernoulli.py
@@ -7,8 +7,8 @@ from typing import List
 
 
 class BernoulliExperiment(BaseThompsonSampling):
-        _default = {"a": 1, "b": 1}
-        _posterior = "beta"
+    _default = {"a": 1, "b": 1}
+    _posterior = "beta"
         
     def __init__(self, arms: int = None, priors: BetaPrior = None, labels: list = None):
         super().__init__(arms, priors, labels)


### PR DESCRIPTION
Your indentation is a bit wrong here  

class BernoulliExperiment(BaseThompsonSampling):
        _default = {"a": 1, "b": 1}
        _posterior = "beta"

when I import your project in Pycharm, it gives indentation error, when I call BernoulliExperiment. 

Fixed this indentation thing and proposing the change Hope you would accept it